### PR TITLE
feat: fire 'headers' event if listener is not provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,17 @@ function createWriteHead (prevWriteHead, listener) {
 }
 
 /**
+ * Emit 'headers' event on response object.
+ */
+
+function emitHeadersEvent() {
+  if (!this.headersEventEmitted) {
+    this.headersEventEmitted = true
+    this.emit('headers')
+  }
+}
+
+/**
  * Execute a listener when a response is about to write headers.
  *
  * @param {object} res
@@ -58,6 +69,9 @@ function onHeaders (res, listener) {
     throw new TypeError('argument res is required')
   }
 
+  if (typeof listener === 'undefined') {
+    listener = emitHeadersEvent
+  }
   if (typeof listener !== 'function') {
     throw new TypeError('argument listener must be a function')
   }


### PR DESCRIPTION
Hi! I'm proposing a feature where this library will emit a `headers` event on the `response` object if no listener is passed as an argument.

This commit lists the changes and added tests but it still missing updating the README file. I'm looking for opinions/feedback/interest on the feature.

Kind regards.