### PR TITLE
test: remove duplicate test for setHeader availability

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -111,17 +111,6 @@ describe('onHeaders(res, listener)', function () {
     })
   })
 
-  describe('setHeader', function () {
-    it('should be available in listener', function (done) {
-      var server = createServer(echoListener)
-
-      request(server)
-        .get('/')
-        .expect('X-Outgoing-Echo', 'test')
-        .expect(200, done)
-    })
-  })
-
   describe('writeHead(status)', function () {
     it('should make status available in listener', function (done) {
       var server = createServer(listener, handler)


### PR DESCRIPTION
Remove duplicate test "should be available in listener" in setHeader
describe block that was identical to the existing "should fire after
setHeader" test. Both tests used the same echoListener and verified
the same functionality.

- Removed: "should be available in listener" (setHeader describe block)
- Kept: "should fire after setHeader" (main describe block)

This reduces test count from 24 to 23 while maintaining full coverage.