### PR TITLE
test: fix getAllHeaderNames to use res parameter instead of this

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -464,6 +464,6 @@ function echoListener () {
 
 function getAllHeaderNames (res) {
   return typeof res.getHeaderNames !== 'function'
-    ? Object.keys(this._headers || {})
+    ? Object.keys(res._headers || {})
     : res.getHeaderNames()
 }


### PR DESCRIPTION
Fix bug in getAllHeaderNames helper function where it incorrectly used 'this._headers' instead of 'res._headers'. This bug would cause the function to fail on Node.js 0.8 (the minimum supported version)
because:

- Node.js 0.8 doesn't have getHeaderNames() method, so it uses the fallback path that reads from _headers
- Inside the function, 'this' is not the response object, so this._headers is undefined
- This would cause getAllHeaderNames to always return [] even when headers exist

The fix changes 'this._headers' to 'res._headers' to correctly use the response object parameter that was passed to the function.

This ensures compatibility with all supported Node.js versions, including Node.js 0.8.