### PR TITLE
fix: handle undefined statusText in writeHead arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,9 @@ function setWriteHeadHeaders (statusCode) {
   var length = arguments.length
   var headerIndex = length > 1 && typeof arguments[1] === 'string'
     ? 2
-    : 1
+    : length > 2
+      ? 2
+      : 1
 
   var headers = length >= headerIndex + 1
     ? arguments[headerIndex]

--- a/test/test.js
+++ b/test/test.js
@@ -221,6 +221,34 @@ describe('onHeaders(res, listener)', function () {
     })
   })
 
+  describe('writeHead(status, undefined, obj)', function () {
+    it('should set headers when statusText is undefined', function (done) {
+      var server = createServer(echoListener, handler)
+
+      function handler (req, res) {
+        res.writeHead(200, undefined, { 'X-Outgoing': 'test' })
+      }
+
+      request(server)
+        .get('/')
+        .expect('X-Outgoing-Echo', 'test')
+        .expect(200, done)
+    })
+
+    it('should set headers when statusText is null', function (done) {
+      var server = createServer(echoListener, handler)
+
+      function handler (req, res) {
+        res.writeHead(200, null, { 'X-Outgoing': 'test' })
+      }
+
+      request(server)
+        .get('/')
+        .expect('X-Outgoing-Echo', 'test')
+        .expect(200, done)
+    })
+  })
+
   describe('writeHead(status, obj)', function () {
     it('should be available in listener', function (done) {
       var server = createServer(listener, handler)


### PR DESCRIPTION
## Summary

Fixes argument parsing in `setWriteHeadHeaders` to correctly handle `writeHead(statusCode, undefined, headers)` — where the statusText is explicitly passed as `undefined` or `null`.

## Problem

When `res.writeHead(200, undefined, { 'X-Custom': 'value' })` is called through `on-headers`, the headers object at the third argument position is silently dropped.

**Root cause:** The argument parsing logic determines the header index based only on whether `arguments[1]` is a string:

```js
var headerIndex = length > 1 && typeof arguments[1] === 'string'
    ? 2
    : 1
```

When `arguments[1]` is `undefined`, it's not a string, so `headerIndex = 1`. Then `arguments[1]` (which is `undefined`) is read as the headers, and the actual headers at `arguments[2]` are never accessed.

**Without `on-headers`:** Native Node.js `writeHead(200, undefined, headers)` works correctly.
**With `on-headers`:** Headers are silently dropped.

This was reported as [expressjs/compression#254](https://github.com/expressjs/compression/issues/254), where the compression middleware (which uses `on-headers`) caused headers to be lost when the Vercel AI SDK called `writeHead(status, undefined, headers)`.

## Fix

When there are more than 2 arguments, the headers are always at index 2 regardless of whether the second argument is a string, matching Node.js native `writeHead` behavior:

```js
var headerIndex = length > 1 && typeof arguments[1] === 'string'
    ? 2
    : length > 2
      ? 2
      : 1
```

## Testing

Added 2 new tests:
- `writeHead(status, undefined, obj)` — headers are set correctly
- `writeHead(status, null, obj)` — headers are set correctly

All 26 tests pass. Lint clean.